### PR TITLE
Fix window flicker

### DIFF
--- a/SimpleCompare/PluginUI.cs
+++ b/SimpleCompare/PluginUI.cs
@@ -4,6 +4,7 @@ using ImGuiNET;
 using Lumina.Excel.Sheets;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using Dalamud.Utility;
 using static FFXIVClientStructs.FFXIV.Client.Game.InventoryItem;
@@ -46,7 +47,17 @@ internal partial class PluginUI : IDisposable
         var equippedItems = GetEquippedItemsByType(inventoryType);
         if (equippedItems.Count <= 0) return;
 
-        if (ImGui.Begin("SimpleCompare", ref _visible, ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoBringToFrontOnFocus | ImGuiWindowFlags.NoFocusOnAppearing | ImGuiWindowFlags.NoNavFocus))
+        var windowFlags = ImGuiWindowFlags.AlwaysAutoResize |
+                          ImGuiWindowFlags.NoDecoration |
+                          ImGuiWindowFlags.NoBringToFrontOnFocus |
+                          ImGuiWindowFlags.NoFocusOnAppearing |
+                          ImGuiWindowFlags.NoNavFocus;
+
+        var mousePos = ImGui.GetMousePos();
+
+        // Anchor top right corner of window to the mouse
+        ImGui.SetNextWindowPos(mousePos - new Vector2(25.0f, 0.0f), ImGuiCond.Always, new Vector2(1.0f, 0.0f));
+        if (ImGui.Begin("SimpleCompare", ref _visible, windowFlags))
         {
             for (var i = 0; i < equippedItems.Count; i++)
             {
@@ -61,16 +72,10 @@ internal partial class PluginUI : IDisposable
                 }
             }
         }
+        ImGui.End();
 
-        var size = ImGui.GetWindowSize();
-        var mousePos = ImGui.GetMousePos();
-        mousePos.X -= size.X + 25;
-        ImGui.SetWindowPos(mousePos, ImGuiCond.Always);
-
-        if (ImGui.Begin("SimpleCompare2", ref _visible,
-                ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoDecoration |
-                ImGuiWindowFlags.NoBringToFrontOnFocus | ImGuiWindowFlags.NoFocusOnAppearing |
-                ImGuiWindowFlags.NoNavFocus))
+        ImGui.SetNextWindowPos(mousePos + new Vector2(25.0f, 0.0f), ImGuiCond.Always);
+        if (ImGui.Begin("SimpleCompare2", ref _visible, windowFlags))
         {
             for (var i = 0; i < equippedItems.Count; i++)
             {
@@ -85,10 +90,6 @@ internal partial class PluginUI : IDisposable
                 }
             }
         }
-
-        mousePos.X += size.X + 50;
-        ImGui.SetWindowPos(mousePos, ImGuiCond.Always);
-
         ImGui.End();
     }
 


### PR DESCRIPTION
Since the window positioning is calculated using the size of the window, and the size isn't known until the window has been rendered at least once (since the text length can change), the windows "flicker" as they are positioned incorrectly on the first frame and then snap into the right place on the second frame they are visible. They also do something similar any time the size of the window changes (e.g. hovering over a different item), though the bigger the change the more noticeable.

By using ImGui.SetNextWindowPos instead, we can pass in a pivot point which lets us set the position of the top right point for the "left" window instead. This gets resolved right at the end after things have mostly rendered , and there's no flickering.

I also noticed that the first window/ImGui.Begin call was missing an End call, so I added that. I also thought that there was something incorrect because the End calls were called outside of the if statements (i.e. called no matter what the return value of Begin was), which is normally not how the ImGui calls work, but looking at the [imgui header file][1], I see that ImGui.Begin (and BeginChild) is different from all the other API calls in this sense, and End should *always* be called.

[1]: https://github.com/ocornut/imgui/blob/d3bb3336f5359dd3bf4af9bb32c2164b31414eac/imgui.h#L366-L368